### PR TITLE
Allow passing in the promise types in order to get a correctly typed promise returned

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -9,7 +9,7 @@ declare namespace PinejsClientCoreFactory {
 	}
 
 	interface PromiseRejector {
-		reject(err: any): Promise<{}>
+		reject(err: any): PromiseLike<any>
 	}
 
 	interface ResourceObj<T> {

--- a/core.d.ts
+++ b/core.d.ts
@@ -143,7 +143,7 @@ declare namespace PinejsClientCoreFactory {
 		options?: ODataOptions
 	}
 
-	export abstract class PinejsClientCore<T> {
+	export abstract class PinejsClientCore<T, PromiseObj extends PromiseLike<{}> = Promise<{}>, PromiseResult extends PromiseLike<number | AnyObject | AnyObject[]> = Promise<number | AnyObject | AnyObject[]>> {
 		apiPrefix: string
 		passthrough: AnyObject
 		passthroughByMethod: AnyObject
@@ -154,30 +154,30 @@ declare namespace PinejsClientCoreFactory {
 
 
 		// `backendParams` must be used by a backend for any additional parameters it may have.
-		clone(params: string | Params, backendParams?: AnyObject): PinejsClientCore<T>
+		clone(params: string | Params, backendParams?: AnyObject): PinejsClientCore<T, PromiseResult, PromiseObj>
 
-		query(params: Params): Promise<number | AnyObject | AnyObject[]>
+		query(params: Params): PromiseResult
 
-		get(params: Params): Promise<number | AnyObject | AnyObject[]>
+		get(params: Params): PromiseResult
 
-		put(params: Params): Promise<{}>
+		put(params: Params): PromiseObj
 
-		patch(params: Params): Promise<{}>
+		patch(params: Params): PromiseObj
 
-		post(params: Params): Promise<{}>
+		post(params: Params): PromiseObj
 
-		delete(params: Params): Promise<{}>
+		delete(params: Params): PromiseObj
 
 		compile(params: Params): string
 
-		request(params: Params, overrides: { method?: ODataMethod }): Promise<{}>
+		request(params: Params, overrides: { method?: ODataMethod }): PromiseObj
 
 		abstract _request(
 			params: {
 				method: string,
 				url: string,
 				body?: AnyObject,
-			} & AnyObject): Promise<{}>
+			} & AnyObject): PromiseObj
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "typed-error": "^0.1.0"
   },
   "devDependencies": {
-    "@types/request": "0.0.43",
+    "@types/bluebird": "^3.5.12",
+    "@types/request": "^2.0.3",
     "chai": "^3.3.0",
     "coffee-script": "~1.11.0",
     "mocha": "^3.5.3",

--- a/request.d.ts
+++ b/request.d.ts
@@ -1,7 +1,8 @@
 import * as PinejsClientCoreFactory from './core'
 import * as request from 'request'
+import * as Promise from 'bluebird'
 
-export = class PinejsClientRequest extends PinejsClientCoreFactory.PinejsClientCore<PinejsClientRequest> {
+export = class PinejsClientRequest extends PinejsClientCoreFactory.PinejsClientCore<PinejsClientRequest, Promise<{}>, Promise<number | PinejsClientCoreFactory.AnyObject | PinejsClientCoreFactory.AnyObject[]>> {
 	constructor(
 		params: string | PinejsClientCoreFactory.Params,
 		backendParams?: {

--- a/request.d.ts
+++ b/request.d.ts
@@ -12,5 +12,5 @@ export = class PinejsClientRequest extends PinejsClientCoreFactory.PinejsClientC
 		}
 	)
 
-	_request: (params: request.Options) => Promise<{}>
+	_request(params: request.Options): Promise<{}>
 }


### PR DESCRIPTION
This allows us to specify the promise as eg a bluebird promise when initialising the class and not have to constantly cast the results if we want to use sugar functions