### PR TITLE
Add support for parameter aliases

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -485,6 +485,12 @@ export function PinejsClientCoreFactory(Promise: PinejsClientCoreFactory.Promise
 			}
 			if (key[0] === '$') {
 				return handleFilterOperator(value, key, parentKey)
+			} else if (key[0] === '@') {
+				if (!isString(value)) {
+					throw new Error(`Parameter alias reference must be a string, got: ${typeof value}`)
+				}
+				const parameterAlias = `@${encodeURIComponent(value)}`
+				return addParentKey(parameterAlias, parentKey)
 			} else {
 				let keys = [key]
 				if (parentKey != null) {
@@ -581,8 +587,15 @@ export function PinejsClientCoreFactory(Promise: PinejsClientCoreFactory.Promise
 				}
 			break
 			default:
+				// Escape parameter aliases as primitives
+				if(option[0] === '@') {
+					if (!isPrimitive(value)) {
+						throw new Error(`Unknown type for parameter alias option '${option}': ${typeof value}`)
+					}
+					compiledValue = '' + escapeValue(value)
+				}
 				// Unknown values are left as-is
-				if (Array.isArray(value)) {
+				else if (Array.isArray(value)) {
 					compiledValue = join(value as string[])
 				} else if (isString(value)) {
 					compiledValue = value

--- a/test/filter.coffee
+++ b/test/filter.coffee
@@ -30,6 +30,13 @@ testOperator = (operator) ->
 
 	testFilter(
 		createFilter
+			a: '@': 'b'
+			c: '@': 'd'
+		"(a eq @b) #{operator} (c eq @d)"
+	)
+
+	testFilter(
+		createFilter
 			a: 'b'
 			c: 'd'
 		"(a eq 'b') #{operator} (c eq 'd')"
@@ -267,6 +274,11 @@ testFilter(
 		b: 'c'
 		$eq: 'd'
 	"(a/b eq 'c') and (a eq 'd')"
+)
+
+testFilter(
+	'@': true
+	new Error('Parameter alias reference must be a string, got: boolean')
 )
 
 # Test raw strings

--- a/test/options.coffee
+++ b/test/options.coffee
@@ -17,6 +17,7 @@ testTop = _.partial(testOption, '$top')
 testSkip = _.partial(testOption, '$skip')
 testSelect = _.partial(testOption, '$select')
 testCustom = _.partial(testOption, 'custom')
+testParam = _.partial(testOption, '@param')
 
 
 testOrderBy(
@@ -115,4 +116,19 @@ testCustom(
 testCustom(
 	true
 	'true'
+)
+
+testParam(
+	'test'
+	"'test'"
+)
+
+testParam(
+	1
+	'1'
+)
+
+testParam(
+	{}
+	new Error("Unknown type for parameter alias option '@param': object")
 )


### PR DESCRIPTION
With this you can do things like
```typescript
api.get({
	resource: 'user',
	options: {
		$filter: $or: {
			username: '@': 'usernameOrEmail',
			email: '@': 'usernameOrEmail'
		},
		'@usernameOrEmail': 'x@example.com'
	}
})
```
which means we can send a parameter just once and opens up possibilities for optimisations on the server as well as potentially precompiling queries in the future

Change-type: minor